### PR TITLE
Upgrade @reach/alert to remove prop-types peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build-storybook": "build-storybook"
   },
   "dependencies": {
-    "@reach/alert": "^0.1.2",
+    "@reach/alert": "^0.10.0",
     "@types/react": "^16.8.10",
     "@types/react-dom": "^16.8.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1200,18 +1200,15 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
-"@reach/alert@^0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@reach/alert/-/alert-0.1.2.tgz#c756e4b448b3e26d1f5646ffd18b1757a52f8603"
-  integrity sha512-VJvmSbGx8R9IDtzaWpN/obc3hUAgXAAwfJ2YjHd+Cld7VS5RzFX32mD50iEzMkgiQdY4/DmsZuejjxF6iFTStg==
+"@reach/alert@^0.10.0":
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/@reach/alert/-/alert-0.10.0.tgz#ed7d709df733efbcbeec8d4e4e5745b26b63b897"
+  integrity sha512-SswD1cU0Gey6MDQwJwcwD7ElnuEIUxZYooefoVBmCrNyG6O/SbOSvUVSRB6yDWcZYANgRjd8xVPa5u9mui1asA==
   dependencies:
-    "@reach/component-component" "^0.1.2"
-    "@reach/visually-hidden" "^0.1.2"
-
-"@reach/component-component@^0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@reach/component-component/-/component-component-0.1.2.tgz#f3c2a53de56d54c8f0ee398485d5831d66e3cc34"
-  integrity sha512-LSsLxBA13qLsfjLtytiuB0siVJSTp0h3hhlJybr90Ynx1SuQ4pRtMi5aUIk7HM3wDswj22YbGC2zOpzibNyN3w==
+    "@reach/utils" "^0.10.0"
+    "@reach/visually-hidden" "^0.10.0"
+    prop-types "^15.7.2"
+    tslib "^1.10.0"
 
 "@reach/router@^1.2.1":
   version "1.2.1"
@@ -1224,10 +1221,20 @@
     react-lifecycles-compat "^3.0.4"
     warning "^3.0.0"
 
-"@reach/visually-hidden@^0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@reach/visually-hidden/-/visually-hidden-0.1.2.tgz#96605cdcbd4585c76b56fed779904423e1f87794"
-  integrity sha512-x/ewdWFlUphyF4pEth5U2FNS29vz/OOxAKcxc+XWbX96XUTobfIvLjYfQWawcP6+Eavy7zGvobpeHj7GVegTRA==
+"@reach/utils@^0.10.0":
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.10.0.tgz#480332433f9d0232aff2c36374cf9a2fe559990b"
+  integrity sha512-qPiwjw8jcT7JYrVT+ZO7bLTVEdp9KyvY0RO1emyCxqpYVr4s9oSZ3XG6n7G+bvnKeyjpbpIfCVfxYvPF1Uq2DQ==
+  dependencies:
+    tslib "^1.10.0"
+    warning "^4.0.3"
+
+"@reach/visually-hidden@^0.10.0":
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/@reach/visually-hidden/-/visually-hidden-0.10.0.tgz#a2d697cfe67a8d25da882889e1d102163e5a2e76"
+  integrity sha512-hhaIpcTNqYKomhVaUNb/CY7fgdC8P8aatfzU1nh2wQfeEOvoEtf8ReQzAvs8/CoknRdJVuo85qGXjkApsKzHow==
+  dependencies:
+    tslib "^1.10.0"
 
 "@storybook/addon-actions@^5.0.5":
   version "5.0.5"
@@ -9490,7 +9497,7 @@ prompts@^0.1.9:
     kleur "^2.0.1"
     sisteransi "^0.1.1"
 
-prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1:
+prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -11485,6 +11492,11 @@ ts-pnp@^1.0.0:
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.0.0.tgz#44a3a9e8c13fcb711bcda75d7b576c21af120c9d"
   integrity sha512-qgwM7eBrxFvZSXLtSvjf3c2mXwJOOGD49VlE+KocUGX95DuMdLc/psZHBnPpZL5b2NU7VtQGHRCWF3cNfe5kxQ==
 
+tslib@^1.10.0:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
+  integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==
+
 tslib@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
@@ -11805,7 +11817,7 @@ warning@^3.0.0:
   dependencies:
     loose-envify "^1.0.0"
 
-warning@^4.0.2:
+warning@^4.0.2, warning@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
   integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==


### PR DESCRIPTION
## Motivation
When running `yarn install` on a project using `toasted-notes`, but not using `prop-types`:
```
warning "toasted-notes > @reach/alert > @reach/component-component@0.1.3" has unmet peer dependency "prop-types@^15.6.2".
```

## Approach
The `prop-types` maintainers recommend using `prop-types` as a dependency, even for libraries.

`reach-ui` followed that direction in https://github.com/reach/reach-ui/pull/277, and released the change with `v0.3.0`.

## Links
- https://github.com/facebook/prop-types#how-to-depend-on-this-package
- https://github.com/facebook/prop-types/issues/44