### PR TITLE
Added support for custom root element

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,19 @@ const CustomNotificationWithTheme = withTheme(CustomNotification);
 toaster.notify(() => <CustomNotificationWithTheme title="I am pretty" />);
 ```
 
+## Custom root element
+
+By default all toasts will be rendered inside a `<div id="react-toast" />` appended dynamically to `<body>`.
+
+You can control where you want to append this element by using the `setRoot` API:
+
+```
+const toastRoot = document.querySelector("main");
+
+toaster.setRoot(toastRoot);
+toaster.notify("Hello World from custom root");
+```
+
 ## Contributors
 
 - [Einar Löve](https://github.com/einarlove)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "toasted-notes",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Flexible, easy to implement toast notifications for react",
   "main": "commonjs/index.js",
   "module": "lib/index.js",

--- a/src/Alert/Toast.tsx
+++ b/src/Alert/Toast.tsx
@@ -12,8 +12,10 @@ class Toaster {
   removeAll?: Function;
   closeToast?: Function;
 
-  constructor() {
-    if (!isBrowser) {
+  private didInit: boolean = false;
+
+  setRoot = (root: HTMLElement) => {
+    if (!isBrowser || this.didInit) {
       return;
     }
 
@@ -26,8 +28,9 @@ class Toaster {
       const el = document.createElement("div");
       el.id = PORTAL_ID;
       el.className = "Toaster";
-      if (document.body != null) {
-        document.body.appendChild(el);
+      if (root != null) {
+        root.appendChild(el);
+        this.didInit = true
       }
       portalElement = el;
     }
@@ -51,13 +54,17 @@ class Toaster {
   };
 
   notify = (message: MessageProp, options: MessageOptionalOptions = {}) => {
+    if (!this.didInit && isBrowser) {
+      this.setRoot(document.body)
+    }
+
     if (this.createNotification) {
       return this.createNotification(message, options);
     }
   };
 
   close = (id: number, position: PositionsType) => {
-    if(this.closeToast){
+    if (this.closeToast) {
       this.closeToast(id, position);
     }
   }


### PR DESCRIPTION
I really like this library because of it's size, especially compared with  [react-toastify](https://github.com/fkhadra/react-toastify). However, not having the ability to insert the Toasts where we want them is a blocker for our team.

In this non-breaking PR I added support for a root element.